### PR TITLE
feat: 시스템이 데이터 추가 시 1번 아이디로 멤버 등록

### DIFF
--- a/src/main/java/com/virtukch/dongiveupbe/domain/quiz/dto/QuizSystemRequestDto.java
+++ b/src/main/java/com/virtukch/dongiveupbe/domain/quiz/dto/QuizSystemRequestDto.java
@@ -30,6 +30,7 @@ public class QuizSystemRequestDto {
 
     public static Quiz toEntity(QuizSystemRequestDto quizSystemRequestDto) {
         return Quiz.builder()
+            .memberId(1L)
             .quizCategory(quizSystemRequestDto.getQuizCategory())
             .quizTitle(quizSystemRequestDto.getQuizTitle())
             .quizType(quizSystemRequestDto.getQuizType())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,4 +3,5 @@ spring:
     active: prod # when deploy -> prod
     # local (ddl-auto: none, DataLoader X, LocalDB)
     # localCreate (ddl-auto: create, DataLoader O, LocalDB)
+    # prod (ddl-auto: none, DataLoader X, AWS DB)
     # prod (ddl-auto: create, DataLoader O, AWS DB)


### PR DESCRIPTION
## 📝작업 내용

> 시스템이 퀴즈 출제 시 1번 아이디로 출제자를 할당했습니다.
> 배포 버전을 두 가지로 하여 prod 와 prodCreate 로 Profile 을 나누었습니다.